### PR TITLE
Checkbox to select all available ITIL categories at once for a metademand

### DIFF
--- a/front/metademand.form.php
+++ b/front/metademand.form.php
@@ -44,6 +44,12 @@ if(isset($_POST['apply_rule'])){
     Html::back();
 }
 
+// override itil_categories_id if checkbox all was checked
+if (isset($_POST['itilcategories_id_all']) && $_POST['itilcategories_id_all'] == 1) {
+    $_POST['itilcategories_id'] = 'all';
+    unset($_POST['itilcategories_id_all']);
+}
+
 if (isset($_POST["add"])) {
 
    $meta->check(-1, CREATE, $_POST);

--- a/front/metademand.form.php
+++ b/front/metademand.form.php
@@ -46,7 +46,7 @@ if(isset($_POST['apply_rule'])){
 
 // override itil_categories_id if checkbox all was checked
 if (isset($_POST['itilcategories_id_all']) && $_POST['itilcategories_id_all'] == 1) {
-    $_POST['itilcategories_id'] = 'all';
+    $_POST['itilcategories_id'] = array_keys(PluginMetademandsMetademand::getAvailableItilCategories($_POST['id']));
     unset($_POST['itilcategories_id_all']);
 }
 

--- a/inc/metademand.class.php
+++ b/inc/metademand.class.php
@@ -1101,9 +1101,13 @@ class PluginMetademandsMetademand extends CommonDBTM
                     $categories = json_encode($array);
                 }
             }
-            $values = $this->fields['itilcategories_id'] ? json_decode($categories) : [];
+            $values = $this->fields['itilcategories_id'] && $this->fields['itilcategories_id'] !== 'all' ? json_decode($categories) : [];
 
-
+            $checked = $this->fields['itilcategories_id'] === 'all' ? 'checked' : '';
+            echo "<div class='custom-control custom-checkbox custom-control-inline'>
+                    <label>" . __('All categories') . "</label>
+                    <input id='itilcategories_id_all' class='form-check-input' type='checkbox' name='itilcategories_id_all' value='1' $checked>
+                </div>";
             echo "<span id='show_category_by_type'>";
             Dropdown::showFromArray(
                 'itilcategories_id',
@@ -1113,6 +1117,12 @@ class PluginMetademandsMetademand extends CommonDBTM
                     'multiple' => true,
                     'entity' => $_SESSION['glpiactiveentities']]
             );
+            echo "<script type='text/javascript'>
+                        $(function() {
+                            let categoriesSelect = document.getElementById('show_category_by_type');
+                            document.getElementById('itilcategories_id_all').addEventListener('change', (e) => categoriesSelect.hidden = e.target.checked)
+                        })
+                    </script>";
             echo "</span>";
             echo "</td>";
             echo "</tr>";


### PR DESCRIPTION
Hide the select multiple field if checked.
On save take all available ITIL categories and set it as value of itilcategories_id.
Checked by default if value of itilcategories_id === available ITIL categories.
![image](https://github.com/InfotelGLPI/metademands/assets/155963006/7654d2a9-610e-4fd9-a341-5a15038cd3d2)
![image](https://github.com/InfotelGLPI/metademands/assets/155963006/f762d597-3c98-4393-be61-b53fc5f14c6f)
