### PR TITLE
bugfix nothing shown in ticket content for dropdown_multiple with User item

### DIFF
--- a/inc/dropdownmultiple.class.php
+++ b/inc/dropdownmultiple.class.php
@@ -1866,6 +1866,10 @@ class PluginMetademandsDropdownmultiple extends CommonDBTM
         } else if ($field['item'] == 'User' && ($field['value'] > 0 || (is_array($field['value']) && count($field['value']) > 0))) {
             $information = json_decode($field['informations_to_display']);
 
+            if (empty($information)) {
+                $information = ['full_name'];
+            }
+
             if ($formatAsTable) {
                 $dataItems = "<table style='border:0;'>";
             }

--- a/inc/dropdownmultiple.class.php
+++ b/inc/dropdownmultiple.class.php
@@ -750,7 +750,8 @@ class PluginMetademandsDropdownmultiple extends CommonDBTM
             echo "</tr>";
             echo "<tr>";
             echo "<td colspan='2' class='center'>";
-            $params['informations_to_display'] = json_decode($params['informations_to_display']) ?? [];
+            $decode = json_decode($params['informations_to_display']);
+            $values = empty($decode) ? ['full_name'] : $decode;
 
             $informations["full_name"] = __('Complete name');
             $informations["realname"] = __('Surname');
@@ -758,9 +759,11 @@ class PluginMetademandsDropdownmultiple extends CommonDBTM
             $informations["name"] = __('Login');
             //                     $informations["group"]             = Group::getTypeName(1);
             $informations["email"] = _n('Email', 'Emails', 1);
-            echo Dropdown::showFromArray('informations_to_display', $informations, ['values' => $params['informations_to_display'],
+            echo Dropdown::showFromArray('informations_to_display', $informations, [
+                'values' => $values,
                 'display' => false,
-                'multiple' => true]);
+                'multiple' => true
+            ]);
             echo "</td>";
             echo "</tr>";
         }
@@ -1866,6 +1869,7 @@ class PluginMetademandsDropdownmultiple extends CommonDBTM
         } else if ($field['item'] == 'User' && ($field['value'] > 0 || (is_array($field['value']) && count($field['value']) > 0))) {
             $information = json_decode($field['informations_to_display']);
 
+            // legacy support
             if (empty($information)) {
                 $information = ['full_name'];
             }

--- a/inc/dropdownobject.class.php
+++ b/inc/dropdownobject.class.php
@@ -422,16 +422,19 @@ class PluginMetademandsDropdownobject extends CommonDBTM
             echo "</tr>";
             echo "<tr>";
             echo "<td colspan='2' class='center'>";
-            $params['informations_to_display'] = json_decode($params['informations_to_display']) ?? [];
+            $decode = json_decode($params['informations_to_display']);
+            $values = empty($decode) ? ['full_name'] : $decode;
             $informations["full_name"]         = __('Complete name');
             $informations["realname"]          = __('Surname');
             $informations["firstname"]         = __('First name');
             $informations["name"]              = __('Login');
             //                  $informations["group"]             = Group::getTypeName(1);
             $informations["email"] = _n('Email', 'Emails', 1);
-            echo Dropdown::showFromArray('informations_to_display', $informations, ['values'   => $params['informations_to_display'],
+            echo Dropdown::showFromArray('informations_to_display', $informations, [
+                'values'   => $values,
                 'display'  => false,
-                'multiple' => true]);
+                'multiple' => true
+            ]);
             echo "</td>";
             echo "</tr>";
             echo "</table>";
@@ -994,6 +997,12 @@ class PluginMetademandsDropdownobject extends CommonDBTM
                     $item = new $field['item']();
                     $content = "";
                     $information = json_decode($field['informations_to_display']);
+
+                    // legacy support
+                    if (empty($information)) {
+                        $information = ['full_name'];
+                    }
+
                     if ($item->getFromDB($field['value'])) {
                         if (in_array('full_name', $information)) {
                             $content .= "" . $field["item"]::getFriendlyNameById($field['value']) . " ";

--- a/inc/field.class.php
+++ b/inc/field.class.php
@@ -3296,6 +3296,13 @@ JAVASCRIPT
         ];
         $id = isset($input['id']) ? $input['id'] : 0;
         foreach ($input as $key => $value) {
+            if ($key === 'informations_to_display' && (in_array($input['type'], ['dropdown_multiple', 'dropdown_object']) && $input['item'] === 'User')) {
+                $temp = json_decode($value);
+                if (empty($temp)) {
+                    $msg[] = __("Informations to display in ticket and PDF", "metademands");
+                    $checkKo = true;
+                }
+            }
             if (array_key_exists($key, $mandatory_fields)) {
                 if (empty($value)) {
                     if (($key == 'item' && ($input['type'] == 'dropdown'


### PR DESCRIPTION
Default value for informations_to_display field set to ['full_name'].
informations_to_display is now mandatory for fields of type dropdown_multiple and dropdown_object associated with User item.

For legacy support : if informations_to_display is an empty array, treated as ['full_name']