### PR TITLE
Fix bug, when you have 2 options or more on dropdown_meta

### DIFF
--- a/scripts/metademands.js
+++ b/scripts/metademands.js
@@ -154,6 +154,10 @@
             $("[id='" + toobserve + "']").change(function () {
                object.metademand_checkEmptyField(toupdate, toobserve, check_value, type);
             });
+         }else if ($("[name='" + toobserve + "']").is('select')) {
+            $("[name='" + toobserve + "']").change(function () {
+               object.metademand_checkEmptyField(toupdate, toobserve, $("[name='" + toobserve + "']")[0].value, type);
+            });
          } else {
             $("[name='" + toobserve + "']").change(function () {
                object.metademand_checkEmptyField(toupdate, toobserve, check_value, type);
@@ -181,7 +185,7 @@
          }
 
          // console.log(obs.val());
-         // console.log(check_value);
+         //console.log(check_value);
          //check_value is not an array
          
          var op1 = (!Array.isArray(check_value) && (check_value != 0 && obs.val() == check_value || check_value == -1 && obs.val() != 0));


### PR DESCRIPTION
When a select have multiple options, 
and one of then have a required field, the field is only required with the last value, 
With this commit, we check the value on the selected field and not inside an array to correct this problem