### PR TITLE
[V11] Correction du crash PHP 8 lors de l'import XML

### DIFF
--- a/src/Export.php
+++ b/src/Export.php
@@ -558,7 +558,7 @@ class Export extends CommonDBTM
 
                 //            if($key == 'name' || $key == 'completename' || $key == 'comments' || $key == 'label2')
                 if ($value !== null) {
-                    $value = htmlspecialchars((string)$value, ENT_NOQUOTES);
+                    $value = htmlspecialchars((string)$value, ENT_NOQUOTES, 'UTF-8');
                     $parent->addChild($key, $value);
                 }
             }
@@ -1357,7 +1357,7 @@ class Export extends CommonDBTM
         $xml = simplexml_load_file($file);
         $json = json_encode($xml);
         $datas = json_decode($json, true);
-        $datas = self::normalizeXmlData($datas);
+        $datas = self::normalizeXmlData($datas) ?? [];
         $metademand = new Metademand();
         $oldId = $datas['id'];
         unset($datas['id']);

--- a/src/Export.php
+++ b/src/Export.php
@@ -557,8 +557,8 @@ class Export extends CommonDBTM
                 }
 
                 //            if($key == 'name' || $key == 'completename' || $key == 'comments' || $key == 'label2')
-                if ($value != null) {
-                    $value = htmlspecialchars($value, ENT_NOQUOTES);
+                if ($value !== null) {
+                    $value = htmlspecialchars((string)$value, ENT_NOQUOTES);
                     $parent->addChild($key, $value);
                 }
             }
@@ -1357,6 +1357,7 @@ class Export extends CommonDBTM
         $xml = simplexml_load_file($file);
         $json = json_encode($xml);
         $datas = json_decode($json, true);
+        $datas = self::normalizeXmlData($datas);
         $metademand = new Metademand();
         $oldId = $datas['id'];
         unset($datas['id']);
@@ -1961,5 +1962,19 @@ class Export extends CommonDBTM
         unlink($file);
 
         return $newIDMeta;
+    }
+
+    private static function normalizeXmlData($data)
+    {
+        if (!is_array($data)) {
+            return $data;
+        }
+        if (count($data) === 0) {
+            return null;
+        }
+        foreach ($data as $k => $v) {
+            $data[$k] = self::normalizeXmlData($v);
+        }
+        return $data;
     }
 }


### PR DESCRIPTION
Sur PHP 8, l'import XML plante avec "Cannot access offset of type array".

Cause : toXml() ignorait les valeurs à zéro (comparaison laxiste != null),
produisant des noeuds XML vides. A l'import, json_decode les convertit en
tableaux vides, que PHP 8 refuse comme clés de tableau.

Fix :
- toXml() : passage en comparaison stricte !== null
- importXml() : ajout de normalizeXmlData() pour gérer les anciens XML
  exportés avec des noeuds vides

Testé sur PHP 8.3 avec un XML contenant des noeuds vides synthétiques
et un round-trip export/import complet.